### PR TITLE
explicitly copy from Jenkins agent location since ENV is reset by new…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,5 @@ RUN apk add --update \
 FROM scratch
 
 COPY --from=builder /usr/local/bin /usr/local/bin
-COPY --from=builder ${JENKINS_AGENT} ${JENKINS_AGENT}
+COPY --from=builder /usr/share/jenkins /usr/share/jenkins
 COPY --from=builder /opt/image-extension /opt/image-extension


### PR DESCRIPTION
… build stage

Too much is copied into the image right now:

```shellsession
$ docker run -it --rm dwolla/jenkins-agent-nucleus ls
bin    etc    lib    mnt    proc   run    srv    tmp    var
dev    home   media  opt    root   sbin   sys    usr
```

`ls` should not be in the image. The desired output is:

```shellsession
$ docker run -it --rm dwolla/jenkins-agent-nucleus ls
docker: Error response from daemon: OCI runtime create failed: container_linux.go:296: starting container process caused "exec: \"ls\": executable file not found in $PATH": unknown.
```